### PR TITLE
Rename header from Correlation-Context to correlationcontext

### DIFF
--- a/abstract/correlation-context-overview.md
+++ b/abstract/correlation-context-overview.md
@@ -1,5 +1,5 @@
 # Overview
 
-Correlation context represented by set of name/value pairs describing user defined properties of the trace. 
+Correlation context represented by set of name/value pairs describing user defined properties of the trace.
 
-`Correlation-Context` header represents user-defined baggage associated with the trace. Libraries and platforms MAY propagate this header.
+`correlationcontext` header represents user-defined baggage associated with the trace. Libraries and platforms MAY propagate this header.

--- a/correlation_context/HTTP_HEADER_FORMAT.md
+++ b/correlation_context/HTTP_HEADER_FORMAT.md
@@ -1,6 +1,6 @@
 # Correlation Context HTTP Header Format
 
-A correlation context header is used to pass the name-value context properties for the trace. This is a companion header for the `traceparent`. The values should be passed along to any child requests. Note that uniqueness of the key within the `Correlation-Context` is not guaranteed. Context received from upstream service may be altered before passing it along.
+A correlation context header is used to pass the name-value context properties for the trace. This is a companion header for the `traceparent`. The values should be passed along to any child requests. Note that uniqueness of the key within the `correlationcontext` is not guaranteed. Context received from upstream service may be altered before passing it along.
 
 *See [rationale document](HTTP_HEADER_FORMAT_RATIONALE.md) for details of decisions made for this format.*
 
@@ -8,7 +8,7 @@ A correlation context header is used to pass the name-value context properties f
 
 ## Header name
 
-`Correlation-Context`
+`correlationcontext`
 
 Multiple correlation context headers are allowed. Values can be combined in a single header according to the [RFC 7230](https://tools.ietf.org/html/rfc7230#page-24).
 
@@ -27,7 +27,7 @@ Url encoded string. Spaces are allows before and after the name. Header with the
 
 ## Value format
 
-Value starts after equal sign and ends with the special character `;`, separator `,` or end of string. Value represents a url encoded string and case sensitive. Spaces are allowed in the beginning and the end of the value. Value with spaces before and after MUST be considered identical to the trimmed value. 
+Value starts after equal sign and ends with the special character `;`, separator `,` or end of string. Value represents a url encoded string and case sensitive. Spaces are allowed in the beginning and the end of the value. Value with spaces before and after MUST be considered identical to the trimmed value.
 
 ## Properties
 
@@ -37,40 +37,40 @@ Spaces are allowed between properties and before and after equal sign. Propertie
 
 # Examples of HTTP headers
 
-Single header: 
+Single header:
 
 ```
-Correlation-Context: userId=sergey,serverNode=DF:28,isProduction=false
+correlationcontext: userId=sergey,serverNode=DF:28,isProduction=false
 ```
 
 Context might be split into multiple headers:
 
 ```
-Correlation-Context: userId=sergey
-Correlation-Context: serverNode=DF%3A28,isProduction=false
+correlationcontext: userId=sergey
+correlationcontext: serverNode=DF%3A28,isProduction=false
 ```
 
 Values and names might begin and end with spaces:
 
 ```
-Correlation-Context: userId =   sergey
-Correlation-Context: serverNode = DF%3A28, isProduction = false
+correlationcontext: userId =   sergey
+correlationcontext: serverNode = DF%3A28, isProduction = false
 ```
 
 ## Example use case
 
 For example, if all of your data needs to be sent to a single node, you could propagate a property indicating that.
 ```
-Correlation-Context: serverNode=DF:28
+correlationcontext: serverNode=DF:28
 ```
 
 For example, if you need to log the original user ID when making transactions arbitrarily deep into a trace.
 ```
-Correlation-Context: userId=sergey
+correlationcontext: userId=sergey
 ```
 
 For example, if you have non-production requests that flow through the same services as production requests.
 ```
-Correlation-Context: isProduction=false
+correlationcontext: isProduction=false
 ```
 

--- a/correlation_context/HTTP_HEADER_FORMAT_RATIONALE.md
+++ b/correlation_context/HTTP_HEADER_FORMAT_RATIONALE.md
@@ -1,46 +1,46 @@
 # Correlation Context Header Format Rationale
 
-This document provides rationale for the decisions made for the `Correlation-Context` header format.
+This document provides rationale for the decisions made for the `correlationcontext` header format.
 
 ## General considerations
 
 - Should be human readable. Cryptic header will hide the fact of potential information disclosure.
-- Should be appende-able (comma-separated) https://tools.ietf.org/html/rfc7230#page-24 so nodes 
+- Should be appende-able (comma-separated) https://tools.ietf.org/html/rfc7230#page-24 so nodes
 can add context properties without parsing an existing headers.
-- It is expected that the typical name will be a single word in latin and the value will be a 
+- It is expected that the typical name will be a single word in latin and the value will be a
 short string in latin or a derivative of an url.
 
 ## Why a single header?
 
-Another option is to use prefixed headers, such as `trace-context-X` where `X` is a propagated 
-field name. This could reduce the size of the data, particularly in http/2 where header 
+Another option is to use prefixed headers, such as `trace-context-X` where `X` is a propagated
+field name. This could reduce the size of the data, particularly in http/2 where header
 compression can apply.
 
-Generally speaking `Correlation-Context` header may be split into multiple headers and 
+Generally speaking `correlationcontext` header may be split into multiple headers and
 compression may be at the same ballpark as repeating values will be converted into a single value
 in HPAC's dynamic collection. That's said there were no profiling made to make this decision.
 
 The approach with multiple headers has the following problems:
-- Name values limitation is much more pressing when the context name is used a part of a header 
+- Name values limitation is much more pressing when the context name is used a part of a header
 name.
-- The comma-separated format similar to the proposed still needs to be supported in every 
+- The comma-separated format similar to the proposed still needs to be supported in every
 individual header. This makes parsing harder.
 - Single header is easier to configure for tracing by many app servers.
 
 ## Why not Vary-style?
 
-The [Vary](https://tools.ietf.org/html/rfc7231#section-7.1.4) approach is another alternative, 
-which could be used to accomplish the same. For example, `Correlation-Context: x-b3-parentid;
-ttl=1` could tell the propagation to look at and forward the parent ID header, but only to the 
-next hop. This has an advantage of http header compression (hpack) and also weave-in with legacy 
+The [Vary](https://tools.ietf.org/html/rfc7231#section-7.1.4) approach is another alternative,
+which could be used to accomplish the same. For example, `correlationcontext: x-b3-parentid;
+ttl=1` could tell the propagation to look at and forward the parent ID header, but only to the
+next hop. This has an advantage of http header compression (hpack) and also weave-in with legacy
 tracing headers.
 
-Vary approach may be implemented as a new "header reference" value type `ref`. 
-`Correlation-Context: x-b3-parentid;type=ref;ttl=1` if proven needed.
+Vary approach may be implemented as a new "header reference" value type `ref`.
+`correlationcontext: x-b3-parentid;type=ref;ttl=1` if proven needed.
 
 ## Trimming of spaces
 
-Header should be human readable and editable. Thus spaces are allowed before and after the comma, equal sign, and semicolon 
+Header should be human readable and editable. Thus spaces are allowed before and after the comma, equal sign, and semicolon
 separators. It makes human-editing of headers less error-prone. It also allows better visual separation of fields when value modified manually.
 
 ## Case sensitivity of names
@@ -51,24 +51,24 @@ There are few considerations why the names should be case sensitive:
 
 ## Strings encoding
 
-Url encoding is low-overhead way to encode unicode characters for non-latin characters in the 
+Url encoding is low-overhead way to encode unicode characters for non-latin characters in the
 values. Url encoding keeps a single words in latin unchanged and easy readable.
 
 ## Limits
 
-The idea behind limits is to provide trace vendors common safeguards so the content of the 
-`Correlation-Context` header can be stored with the request. Thus the limits are defined on the 
-number of keys, max pair length and the total size. The last limit is the most important in many 
+The idea behind limits is to provide trace vendors common safeguards so the content of the
+`correlationcontext` header can be stored with the request. Thus the limits are defined on the
+number of keys, max pair length and the total size. The last limit is the most important in many
 scenarios as it allows to plan for the data storage limits.
 
-Another consideration was that HTTP cookies provide a similar way to pass custom data via HTTP 
-headers. So the limits should make the correlation context name-value pairs fit the typical 
+Another consideration was that HTTP cookies provide a similar way to pass custom data via HTTP
+headers. So the limits should make the correlation context name-value pairs fit the typical
 cookie limits.
 
-- *Maximum number of name-value pairs* - this limit was taken as a number of cookies allowed by 
+- *Maximum number of name-value pairs* - this limit was taken as a number of cookies allowed by
 Chrome.
-- *Maximum number of bytes per a single name-value pair* - the limit allows to store URL as a 
-value with some extra details as a single context name-value pair. It is also a typical cookie 
+- *Maximum number of bytes per a single name-value pair* - the limit allows to store URL as a
+value with some extra details as a single context name-value pair. It is also a typical cookie
 size limitation.
 - *Maximum total length of all name-value pairs* - TODO: LOOKING FOR SUGGESTIONS HERE
 

--- a/correlation_context/README.md
+++ b/correlation_context/README.md
@@ -1,9 +1,9 @@
-# Correlation-Context Header
+# correlationcontext Header
 
-Correlation context header is used to propagate properties not defined in `Trace-Parent`. There 
-are two common use cases. First is to define a context on trace initiation. Such context will 
-have customer's identity, high-level operation name and other properties like a flight name. 
-Second use case is to pass the caller's name to the next component. This name-value pair will be 
+Correlation context header is used to propagate properties not defined in `traceparent`. There
+are two common use cases. First is to define a context on trace initiation. Such context will
+have customer's identity, high-level operation name and other properties like a flight name.
+Second use case is to pass the caller's name to the next component. This name-value pair will be
 overridden by every service to it's own name.
 
 ## HTTP Format


### PR DESCRIPTION
The reason for this change is to make the header interoperable with non-HTTP protocols that may have more restrictions on header naming than HTTP. This follows the conventions used for the trace context headers: traceparent and tracestate.

See #13 for more discussion.